### PR TITLE
Move population of baseFolder from image process to container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,26 +22,15 @@ run mkdir -p /opt/gitblit
 run tar zxf /root/gitblit.tar.gz -C /opt/gitblit
 run rm -f /root/gitblit.tar.gz
 
-# Move the data files to a separate directory
-run mkdir -p /opt/gitblit-data
-run mv /opt/gitblit/data/* /opt/gitblit-data
-run mv /opt/gitblit-data/gitblit.properties /opt/gitblit-data/default.properties
 
-# Adjust the default Gitblit settings to bind to 80, 9418, 29418, and allow RPC administration.
-#
-# Note: we are writing to a different file here because sed doesn't like to the same file it
-# is streaming.  This is why the original properties file was renamed earlier.
-run sed -e "s/server\.httpsPort\s=\s8443/server\.httpsPort=0/" \
-        -e "s/server\.httpPort\s=\s0/server\.httpPort=80/" \
-        -e "s/web\.enableRpcManagement\s=\sfalse/web\.enableRpcManagement=true/" \
-        -e "s/web\.enableRpcAdministration\s=\sfalse/web.enableRpcAdministration=true/" \
-        -e "s/server\.contextPath\s=\s\//server.contextPath=\/gitblit\//" \
-        /opt/gitblit-data/default.properties > /opt/gitblit-data/gitblit.properties
+run mkdir -p /opt/gitblit-data
 
 # Setup the Docker container environment and run Gitblit
 VOLUME /opt/gitblit-data
 workdir /opt/gitblit
+copy run.sh /bin/
+run chmod 755 /bin/run.sh
 expose 80
 expose 9418
 expose 29418
-cmd ["java", "-server", "-Xmx1024M", "-Djava.awt.headless=true", "-jar", "/opt/gitblit/gitblit.jar", "--baseFolder", "/opt/gitblit-data"]
+cmd ["/bin/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# check to see if GitBlit's properties file already exists and, if not, copy in all the config data
+# This allows us to rebind the baseFolder to an attached data-only volume
+
+if [ ! -f /opt/gitblit-data/gitblit.properties ]; then
+    cp -a /opt/gitblit/data/* /opt/gitblit-data
+
+    # Adjust the default Gitblit settings to bind to 80, 9418, 29418, and allow RPC administration.
+
+    sed -e "s/server\.httpsPort\s=\s8443/server\.httpsPort=0/" \
+        -e "s/server\.httpPort\s=\s0/server\.httpPort=80/" \
+        -e "s/web\.enableRpcManagement\s=\sfalse/web\.enableRpcManagement=true/" \
+        -e "s/web\.enableRpcAdministration\s=\sfalse/web.enableRpcAdministration=true/" \
+        -e "s/server\.contextPath\s=\s\//server.contextPath=\/gitblit\//" \
+        /opt/gitblit/data/gitblit.properties > /opt/gitblit-data/gitblit.properties
+
+fi
+
+java -server -Xmx1024M -Djava.awt.headless=true -jar /opt/gitblit/gitblit.jar --baseFolder /opt/gitblit-data


### PR DESCRIPTION
These changes defer the population of /opt/gitblit-data to the container's startup process. This creates the ability to mount /opt/glitblit-data from a separate data-volume container at runtime.